### PR TITLE
 Remove unneeded netcdf.inc include statement

### DIFF
--- a/src/core/write_ocean_obs.F90
+++ b/src/core/write_ocean_obs.F90
@@ -24,7 +24,6 @@ logical :: module_is_initialized=.false.
 
 public :: open_profile_file, write_profile, close_profile_file, write_ocean_obs_init
 
-#include <netcdf.inc>
 
 contains
 


### PR DESCRIPTION
the netcdf.inc include statement is unnecessary and was causing a
compile issue for me.

As we've discussed, the write_ocean_obs.F90 file isn't even used, so if you want to delete this file entirely that is up to you. If you think you'll need it in the future, please merge this and leave it there.
